### PR TITLE
#8 logger package

### DIFF
--- a/.env
+++ b/.env
@@ -1,11 +1,8 @@
 # Local Database Config
 DB_HOST=localhost
 DB_PORT=5432
-DB_USERNAME=postgres    
-DB_PASSWORD=postgres
+DB_USERNAME=auth_user    
+DB_PASSWORD=pass
 DB_NAME=bark
 DB_SSL_MODE=disable
-
-
-
 APPPORT=:8081

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,87 @@
+package logger
+
+import (
+	"encoding/json"
+	"log"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/techrail/bark/db"
+	. "github.com/techrail/bark/models"
+)
+
+func Init() {
+	err := godotenv.Load("../.env")
+	if err != nil {
+		log.Fatal("Error loading .env file")
+	}
+}
+
+type Logger struct {
+	ServiceName string
+}
+
+func NewLogger(serviceName string) *Logger {
+	return &Logger{
+		ServiceName: serviceName,
+	}
+}
+
+func (l *Logger) Log(logLevel int, code, message string, moreData json.RawMessage, database *db.BarkPostgresDb) {
+	logEntry := BarkLog{
+		LogTime:     time.Now(),
+		LogLevel:    logLevel,
+		ServiceName: l.ServiceName,
+		Code:        code,
+		Message:     message,
+		MoreData:    moreData,
+	}
+	database.InsertLog(logEntry)
+}
+
+func GetLogger(serviceName string) func(int, string, string, json.RawMessage) {
+	logger := NewLogger(serviceName)
+	Init()
+	db, err := db.ConnectToDatabase()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return func(logLevel int, code, message string, moreData json.RawMessage) {
+		logger.Log(logLevel, code, message, moreData, db)
+	}
+}
+
+func ReadFromChannel(logChannel <-chan BarkLog) []BarkLog {
+	var logsFromChannel []BarkLog
+	for val := range logChannel {
+		logsFromChannel = append(logsFromChannel, val)
+	}
+	return logsFromChannel
+}
+
+func WriteToChannel(logChannel chan BarkLog, logRecord BarkLog) {
+	logChannel <- logRecord
+}
+
+// go routine to check channel length and commit to DB
+func BatchCommit(logChannel chan BarkLog) string {
+	logChannelLength := 0
+	for {
+		logChannelLength = len(logChannel)
+		if logChannelLength > 100 {
+			//commit in batches of 100
+			logsToCommit := ReadFromChannel(logChannel)
+			for i := 0; i < len(logsToCommit); i++ {
+				// call bulk insert function
+			}
+		} else if logChannelLength > 0 && logChannelLength < 100 {
+			// commit one at a time
+			logsToCommit := ReadFromChannel(logChannel)
+			for i := 0; i < len(logsToCommit); i++ {
+				// call insert
+			}
+		} else {
+			time.Sleep(1 * time.Second)
+		}
+	}
+}

--- a/tests/logger_test.go
+++ b/tests/logger_test.go
@@ -1,0 +1,40 @@
+package tests
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/techrail/bark/db"
+	"github.com/techrail/bark/logger"
+)
+
+func TestGetLogger(t *testing.T) {
+	serviceName := "TestService"
+	bark := logger.GetLogger(serviceName)
+
+	weirdJsonData, _ := json.Marshal(map[string]interface{}{
+		"weird_key_1": "destroy the world",
+		"weird_key_2": "or may wait until tomorrow",
+	},
+	)
+
+	bark(0, "901101", "This logger rocks!", weirdJsonData)
+
+	database, err := db.ConnectToDatabase()
+
+	if err != nil {
+		t.Log("Failed to connect to database for verificaiton")
+		t.Fail()
+	}
+
+	logs, err := database.FetchLimitedLogs(100)
+
+	for i := 0; i < 100; i++ {
+		t.Log(logs[i].Message)
+		if logs[i].Message == "This logger rocks!" {
+			return
+		}
+	}
+	t.Log("Unable to find the inserted log")
+	t.Fail()
+}


### PR DESCRIPTION
As described in #8 I have added a logger package that can be imported into other projects along with some unit tests.

Some considerations or improvements to be made that I haven't added right now:

- Right now database connection is solely based on env variables, I think the library's end user might need the ability to provide a custom database when he's initializing the logger.
- I have added the entirety of the BarkLog model, in the logger function, this should be improved. I think we shouldn't leave the responsibility of generating code, or log level to the user unless he wants it. Maybe something like `log.info` or `log.debug` like we have in Log4j in Java.
- Unit tests don't clean the data that it insert.

To run test: `go test ./tests` (this doesn't do much, but still should print `ok`)

**Other Minor Changes:** Changed the password in the `.env` file to be consistent with a docker-compose file that we have.