### PR TITLE
Added sqlx tests for db benchmark

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 # Local Database Config
 DB_HOST=localhost
 DB_PORT=5432
-DB_USERNAME=auth_user    
-DB_PASSWORD=pass
+DB_USERNAME=postgres    
+DB_PASSWORD=postgres
 DB_NAME=bark
 DB_SSL_MODE=disable
 APPPORT=:8081

--- a/tests/db_sqlx_test.go
+++ b/tests/db_sqlx_test.go
@@ -1,0 +1,111 @@
+package tests
+
+import (
+	"encoding/json"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/techrail/bark/db"
+	"github.com/techrail/bark/models"
+)
+
+func Init() {
+	err := godotenv.Load("../.env")
+	if err != nil {
+		log.Fatal("Error loading .env file")
+	}
+}
+func TestDBConnection(t *testing.T) {
+	Init()
+	_, err := db.ConnectToDatabase()
+	if err != nil {
+		log.Fatalf("Failed to connect to the database: %v", err)
+	}
+}
+
+func TestInsertLog(t *testing.T) {
+	Init()
+
+	db, err := db.ConnectToDatabase()
+
+	moreData, _ := json.Marshal(map[string]interface{}{
+		"a": "apple",
+		"b": "banana",
+	},
+	)
+	sampleLog := models.BarkLog{
+		LogTime:     time.Now(),
+		LogLevel:    0,
+		ServiceName: "test",
+		Code:        "1234",
+		Message:     "Test",
+		MoreData:    moreData}
+
+	if err != nil {
+		log.Fatalf("Failed to connect to the database: %v", err)
+	}
+	err = db.InsertLog(sampleLog)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func TestInsertBatch(t *testing.T) {
+	Init()
+
+	db, err := db.ConnectToDatabase()
+	moreData, _ := json.Marshal(map[string]interface{}{
+		"a": "apple",
+		"b": "banana",
+	},
+	)
+	sampleLogs := []models.BarkLog{
+		// Id:          1234,
+		{LogTime: time.Now(),
+			LogLevel:    0,
+			ServiceName: "test",
+			Code:        "1234",
+			Message:     "Test",
+			MoreData:    moreData},
+		{LogTime: time.Now(),
+			LogLevel:    0,
+			ServiceName: "test",
+			Code:        "1234",
+			Message:     "Test",
+			MoreData:    moreData},
+		{LogTime: time.Now(),
+			LogLevel:    0,
+			ServiceName: "test",
+			Code:        "1234",
+			Message:     "Test",
+			MoreData:    moreData},
+		{LogTime: time.Now(),
+			LogLevel:    0,
+			ServiceName: "test",
+			Code:        "1234",
+			Message:     "Test",
+			MoreData:    moreData},
+	}
+	if err != nil {
+		log.Fatalf("Failed to connect to the database: %v", err)
+	}
+	err = db.InsertBatch(sampleLogs)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func TestFetchLogs(t *testing.T) {
+	Init()
+
+	db, err := db.ConnectToDatabase()
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, err = db.FetchLimitedLogs(10)
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
This adds four test cases:
1. Open a db connection
2. Insert a single log
3. Insert a batch of four logs
4. Fetch 10 logs  

The results I got are :
```
➜  tests git:(sqlx-pq-benchmark) ✗ go test -v -run TestDBConnection
=== RUN   TestDBConnection
--- PASS: TestDBConnection (0.01s)
PASS
ok      github.com/techrail/bark/tests  0.009s
➜  tests git:(sqlx-pq-benchmark) ✗ go test -v -run TestInsertLog   
=== RUN   TestInsertLog
--- PASS: TestInsertLog (0.01s)
PASS
ok      github.com/techrail/bark/tests  0.014s
➜  tests git:(sqlx-pq-benchmark) ✗ go test -v -run TestInsertBatch
=== RUN   TestInsertBatch
Rows inserted  4
--- PASS: TestInsertBatch (0.01s)
PASS
ok      github.com/techrail/bark/tests  0.014s
➜  tests git:(sqlx-pq-benchmark) ✗ go test -v -run TestFetchLogs  
=== RUN   TestFetchLogs
--- PASS: TestFetchLogs (0.01s)
PASS
ok      github.com/techrail/bark/tests  0.010s
```