### PR TITLE
add env for connection string

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 # Local Database Config
+DATABASE_URL=""
 DB_HOST=localhost
 DB_PORT=5432
 DB_USERNAME=auth_user    

--- a/resources/db.go
+++ b/resources/db.go
@@ -1,11 +1,12 @@
 package resources
 
 import (
-	`context`
-	`fmt`
+	"context"
+	"fmt"
+	"os"
 
-	`github.com/jmoiron/sqlx`
-	_ `github.com/lib/pq`
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
 )
 
 // BarkPostgresDb wraps the sqlx.DB in a custom struct to use it as a receiver for query functions
@@ -33,7 +34,12 @@ func InitDatabase() error {
 }
 
 func OpenDatabase() (*BarkPostgresDb, error) {
-	dbConn, err := sqlx.Open("postgres", "postgres://vaibhavkaushal:vaibhavkaushal@127.0.0.1:5432/bark?sslmode=disable")
+	databaseConnectionString := fmt.Sprintf(
+		"postgres://%s:%s@%s:%s/%s?sslmode=%s",
+		os.Getenv("DB_USERNAME"), os.Getenv("DB_PASSWORD"), os.Getenv("DB_HOST"), os.Getenv("DB_PORT"), os.Getenv("DB_NAME"), os.Getenv("DB_SSL_MODE"),
+	)
+
+	dbConn, err := sqlx.Open("postgres", databaseConnectionString)
 
 	if err != nil {
 		return &BarkPostgresDb{}, fmt.Errorf("E#1KDW57 - error connecting to db: %w", err)

--- a/resources/db.go
+++ b/resources/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
@@ -36,7 +37,7 @@ func InitDatabase() error {
 func OpenDatabase() (*BarkPostgresDb, error) {
 
 	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
+	if strings.TrimSpace(os.Getenv("DATABASE_URL")) == "" {
 		return &BarkPostgresDb{}, fmt.Errorf("No env found or empty")
 	}
 

--- a/resources/db.go
+++ b/resources/db.go
@@ -34,13 +34,13 @@ func InitDatabase() error {
 }
 
 func OpenDatabase() (*BarkPostgresDb, error) {
-	databaseConnectionString := fmt.Sprintf(
-		"postgres://%s:%s@%s:%s/%s?sslmode=%s",
-		os.Getenv("DB_USERNAME"), os.Getenv("DB_PASSWORD"), os.Getenv("DB_HOST"), os.Getenv("DB_PORT"), os.Getenv("DB_NAME"), os.Getenv("DB_SSL_MODE"),
-	)
 
-	dbConn, err := sqlx.Open("postgres", databaseConnectionString)
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		return &BarkPostgresDb{}, fmt.Errorf("No env found or empty")
+	}
 
+	dbConn, err := sqlx.Open("postgres", databaseURL)
 	if err != nil {
 		return &BarkPostgresDb{}, fmt.Errorf("E#1KDW57 - error connecting to db: %w", err)
 	}


### PR DESCRIPTION
Fixes #14 
The connection string is imported from the `.env` file instead of a hard coded value.

