### PR TITLE
Added Functionality for Batch Insertion of Logs

### DIFF
--- a/controllers/log_ingestion.go
+++ b/controllers/log_ingestion.go
@@ -1,13 +1,13 @@
 package controllers
 
 import (
-	`encoding/json`
+	"encoding/json"
 
-	`github.com/valyala/fasthttp`
+	"github.com/valyala/fasthttp"
 
-	`github.com/techrail/bark/appRuntime`
-	`github.com/techrail/bark/models`
-	`github.com/techrail/bark/services/ingestion`
+	"github.com/techrail/bark/appRuntime"
+	"github.com/techrail/bark/models"
+	"github.com/techrail/bark/services/ingestion"
 )
 
 func SendSingleToChannel(ctx *fasthttp.RequestCtx) {
@@ -46,7 +46,7 @@ func SendMultipleToChannel(ctx *fasthttp.RequestCtx) {
 
 	var multipleLogEntries []models.BarkLog
 	if err := json.Unmarshal(body, &multipleLogEntries); err != nil {
-		ctx.Error("E#1KDWRF - Invalid request body structure", fasthttp.StatusBadRequest)
+		ctx.Error("E#1KDWRF - Invalid request body structure: "+err.Error(), fasthttp.StatusBadRequest)
 		return
 	}
 

--- a/models/barklog.go
+++ b/models/barklog.go
@@ -90,15 +90,41 @@ func (bld *BarkLogDao) Insert(l BarkLog) error {
 	return nil
 }
 
-func (bld *BarkLogDao) InsertBatch(l []BarkLog) error {
-	panic("E#1KGYSG - NOT YET IMPLEMENTED")
+func (bld *BarkLogDao) InsertBatch(logs []BarkLog) error {
+
+	query := `
+	INSERT INTO app_log (
+		log_time, log_level, service_name,
+		session_name, code, msg, 
+        more_data
+	) 
+	VALUES `
+
+	numOfLogs := len(logs)
+	logsToInsert := make([]interface{}, numOfLogs*7)
+
+	for i, log := range logs {
+		pos := i * 7
+		logsToInsert[pos+0] = log.LogTime
+		logsToInsert[pos+1] = log.LogLevel
+		logsToInsert[pos+2] = log.ServiceName
+		logsToInsert[pos+3] = log.SessionName
+		logsToInsert[pos+4] = log.Code
+		logsToInsert[pos+5] = log.Message
+		logsToInsert[pos+6] = log.MoreData
+
+		query += "(?, ?, ?, ?, ?, ?, ?)"
+
+		if i < numOfLogs-1 {
+			query += ","
+		}
+	}
+
+	_, err := resources.BarkDb.Client.Queryx(query, logsToInsert)
+
+	if err != nil {
+		return fmt.Errorf("Error while inserting multiple logs: %w", err)
+	}
+
 	return nil
-
-	// query := `
-	// INSERT INTO app_log
-	//     (log_time, log_level, service_name,session_name, code, msg, more_data)
-	// VALUES
-	//     ($1, $2, $3, $4, $5, $6, $7)`
-	//     ($8, $9, $10, $11, $12, $13, $14)`
-
 }

--- a/services/dbLogWriter/db_log_writer.go
+++ b/services/dbLogWriter/db_log_writer.go
@@ -1,12 +1,12 @@
 package dbLogWriter
 
 import (
-	`fmt`
-	`time`
+	"fmt"
+	"time"
 
-	`github.com/techrail/bark/appRuntime`
-	`github.com/techrail/bark/channels`
-	`github.com/techrail/bark/models`
+	"github.com/techrail/bark/appRuntime"
+	"github.com/techrail/bark/channels"
+	"github.com/techrail/bark/models"
 )
 
 var BarkLogDao *models.BarkLogDao
@@ -31,9 +31,6 @@ func StartWritingLogs() {
 				}
 				logBatch = append(logBatch, elem)
 			}
-			// =====================================================
-			// IMPORTANT: Finish InsertBatch function implementation
-			// =====================================================
 			err := BarkLogDao.InsertBatch(logBatch)
 			if err != nil {
 				fmt.Println(err)


### PR DESCRIPTION
Adding the feature to enable batch insertion of logs. Instead of making individual database calls for each log entry, we now append multiple BarkLog instances onto the query string and submit them to the DB client.

Addressing #13 