### PR TITLE
Removed the use of env variable DATABASE_URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,7 @@
-# Local Database Config
-DATABASE_URL=""
 DB_HOST=localhost
 DB_PORT=5432
-DB_USERNAME=postgres    
-DB_PASSWORD=postgres
+DB_USERNAME=auth_user
+DB_PASSWORD=pass
 DB_NAME=bark
 DB_SSL_MODE=disable
 APPPORT=:8081

--- a/resources/db.go
+++ b/resources/db.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
@@ -35,11 +34,12 @@ func InitDatabase() error {
 }
 
 func OpenDatabase() (*BarkPostgresDb, error) {
-
-	databaseURL := os.Getenv("DATABASE_URL")
-	if strings.TrimSpace(os.Getenv("DATABASE_URL")) == "" {
-		return &BarkPostgresDb{}, fmt.Errorf("No env found or empty")
-	}
+	databaseURL := fmt.Sprintf(
+		"user=%s password=%s host=%s port=%s dbname=%s sslmode=%s",
+		os.Getenv("DB_USERNAME"), os.Getenv("DB_PASSWORD"),
+		os.Getenv("DB_HOST"), os.Getenv("DB_PORT"), os.Getenv("DB_NAME"),
+		os.Getenv("DB_SSL_MODE"),
+	)
 
 	dbConn, err := sqlx.Open("postgres", databaseURL)
 	if err != nil {


### PR DESCRIPTION
Removed the use of env variable `DATABASE_URL`.
Database URL should be created on run-time using other relevant environment variables such as `DB_USER`, `DB_PASSWORD` etc 