### PR TITLE
Reduce allocs

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -2,7 +2,7 @@
 
 ## IMPORTANT: It is not Yet Built
 
-## What does the client do? 
+## What does the client do?
 The Bark client (just _client_ henceforth) is the _library_ side of the bark. It is the piece that takes in the logs from any golang program and sends it to the server which is configured against the client. It is supposed to have the utility functions to help users log to bark directly from go code without having to worry about network calls and such.
 
 ## Levels of Logs
@@ -19,11 +19,11 @@ The client defines 7 levels of logs:
 Any single character in the place of error level in a parsable single log message would indicate the level of **INFO**.
 
 ## Simple usecase
-The client can be initialized and used as follows (we explain the options below code sample): 
+The client can be initialized and used as follows (we explain the options below code sample):
 
 ```go
-barkClient := client.NewClient("<bark_server_url>", "<default_log_level>", "<default_service_name>", "<session_name>", 
-    "<enable_slog", "<enable_bulk_dispatch>")
+barkClient := client.NewClient("<bark_server_url>", "<default_log_level>", "<default_service_name>", "<session_name>",
+"<enable_slog", "<enable_bulk_dispatch>")
 
 barkClient.Panic("E#1LPW24 - Panic message")
 barkClient.Alert("E#1LPW25 - Alert message", false)
@@ -41,12 +41,12 @@ The options that are used for initializing the client are as follows:
 - **bark_server_url**: This is the URL of a running bark server. It must end in `/`. For example `http://bark.example.com/` or `http://127.0.0.1:8080/`
 - **default_log_level**: When you use `Println` or `Default`, the log message is parsed (rules for prasing are described [here](../_nocode/docs/log-string-parsing-in-bark.md)) and if it does not contain any indication for what the log level is, then the value supplied in this field is used as the log level for sent log message. When using dedicated methods for error levels (e.g. `Panic`, `Error` etc.), the parsed error level is overwritten.
 - **default_service_name**: This is the name of the service which is sending the log - so it has to be the name of the program or service which is calling it. In case a blank string is sent, the value against `constants.DefaultLogServiceName` (currently set to `def_svc`) is used.
-- **session_name**: This is the name of the calling app's session. This value is supposed to indicate which instance among possibly multiple instances of a service sent a log message. For example, in case of the service being deployed within Kubernetes, it might indicate the service's pod's name. If the value is sent as a blank string, client will try to use the machine's hostname. If it fails to fetch the hostname, a random string will be used instead. 
+- **session_name**: This is the name of the calling app's session. This value is supposed to indicate which instance among possibly multiple instances of a service sent a log message. For example, in case of the service being deployed within Kubernetes, it might indicate the service's pod's name. If the value is sent as a blank string, client will try to use the machine's hostname. If it fails to fetch the hostname, a random string will be used instead.
 - **enable_slog**: This enables [slog](https://go.dev/blog/slog) for the client. When this option is enabled, all logs in addition to being sent to the bark server is also printed on STDOUT of the service.
 - **enable_bulk_dispatch**: Setting this to true would enable the client to push all the requests being received in a channel and start using it. It improves the overall performance of the client sending log entries to the server.
 
 ### Simplest usecase (without any server)
-The simplest usecase of any logging library is to print to STDOUT. While the primary usecase of bark is to be able to dispatch log messages to a remote server, when we start off with a new project, we often just want to start logging things to STDOUT. Maybe even later, that is how we want to use logs. For such usecases, the client library offers `NewSloggerClient` which uses the built in [slog](https://go.dev/blog/slog) package in go (version 1.21+) to log your messages to STDOUT with levels. Example: 
+The simplest usecase of any logging library is to print to STDOUT. While the primary usecase of bark is to be able to dispatch log messages to a remote server, when we start off with a new project, we often just want to start logging things to STDOUT. Maybe even later, that is how we want to use logs. For such usecases, the client library offers `NewSloggerClient` which uses the built in [slog](https://go.dev/blog/slog) package in go (version 1.21+) to log your messages to STDOUT with levels. Example:
 
 ```go
 log := client.NewSloggerClient("INFO")
@@ -60,7 +60,7 @@ log.Info("Info message")
 log.Debug("Debug message")
 log.Println("Println message")
 ```
-The above piece of code will end up printing something like the following (the dates in the beginning of each line will vary): 
+The above piece of code will end up printing something like the following (the dates in the beginning of each line will vary):
 
 ```
 2023/10/15 21:57:41 PANIC Panic message
@@ -73,83 +73,87 @@ The above piece of code will end up printing something like the following (the d
 2023/10/15 21:57:41 INFO Println message
 ```
 
-### Redirecting the output to a file
+## Printing logs to a file
+Bark client, as shown above, is capable of sending logs to a server as well as printing them to the standard output as well. It can also do both of those things simultaneously. The architecture in very simple representation looks like this:
 
-> [!IMPORTANT]  
-This section outlines the behavior of log printing when `enable_slog` is enabled during client initialization. It's important to note that this configuration does not affect how logs are sent to the Bark database. The `NewClient` and `NewClientWithServer` functions are designed to transmit logs to the Bark server or database. If you prefer not to send logs to the server, consider using the `NewSloggerClient` function.
+![barkslogger.svg](../_nocode/images/barkslogger.svg)
 
+You can use any of the log methods available in bark client to do this. If you want to print the logs to a different output, such as a file, you can use the `SetCustomOut` method. This method takes an `io.Writer` parameter and sets it as the output writer for the bark client. For example, if you want to print the logs to a file named random.txt, you can do this:
 
-To reroute logs to a file instead of the console (assuming `enable_slog` is set to true during client initialization), you can use the `WithCustomOut` method, accepting an `io.Writer` parameter. 
-Here's a sample usage:
 ```go
-logger := client.NewClient("<bark_server_url>", "<custom_log_level>", "<service_name>", "<session_name>", true, "<enable_bulk_dispatch_to_server>")
+log := client.NewClient("http://127.0.0.1:8080/", "INFO", "BarkClientFileTest", "TestClientSession", true, false)
 
-file, _ := os.Create("<any file name>")
+file, err := os.Create("random.txt")
+if err != nil {
+	fmt.Println("Error when creating new file: ", err)
+	return
+}
 
-log.WithCustomOut(file)
+log.SetCustomOut(file)
 
-log.Panic("Panic message")
-log.Alert("Alert message", true)
-log.Error("Error message")
-log.Warn("Warn message")
-log.Notice("Notice message")
-log.Info("Info message")
-log.Debug("Debug message")
-log.Println("Println message")
+log.Info("Some Message that'll be sent to random.txt file")
+log.WaitAndEnd()
+```
+The above code will write the output to `random.txt` file. You can expect the file to contain something like this:
+
+```text
+2023/10/18 19:27:51 INFO Some Message that'll be sent to random.txt file
 ```
 
-This code configures a logger to direct log output to a designated file, showcasing multiple log levels.
-
-The above piece of code will end up printing to the specified file, something like the following (the dates in the beginning of each line will vary):
-```
-2023/10/15 21:57:41 PANIC Panic message
-2023/10/15 21:57:41 ALERT Alert message
-2023/10/15 21:57:41 ERROR Error message
-2023/10/15 21:57:41 WARN Warn message
-2023/10/15 21:57:41 NOTICE Notice message
-2023/10/15 21:57:41 INFO Info message
-2023/10/15 21:57:41 DEBUG Debug message
-2023/10/15 21:57:41 INFO Println message
-```
-
-### Handling output with slog Handlers
-
-> [!IMPORTANT]  
-This section outlines the behavior of log printing when `enable_slog` is enabled during client initialization. It's important to note that this configuration does not affect how logs are sent to the Bark database. The `NewClient` and `NewClientWithServer` functions are designed to transmit logs to the Bark server or database. If you prefer not to send logs to the server, consider using the `NewSloggerClient` function.
-
+### Slog and writing to a file
 
 Bark client uses [slog](https://go.dev/blog/slog) internally to handle the printing of the logs. Slog is a simple and structured logging library that comes with Go (version 1.21+).
 
 You can customize how slog prints the logs by specifying a [handler](https://pkg.go.dev/log/slog#Handler). A handler is a function that takes a log record and writes it to an output. Slog provides some built-in handlers, such as [JSONHandler](https://pkg.go.dev/log/slog#JSONHandler) and [TextHandler](https://pkg.go.dev/log/slog#TextHandler), or you can write your own.
 
-To specify a handler for the bark client, you can use the `WithSlogHandler` method. This method takes a `handler` function as a parameter and sets it as the handler for the slog logger. For example, if you want to use the `JSONHandler` and print the logs as JSON objects to a file named `random.txt`, you can do this:
+**_Note:_** Changing the handler will only affect how the logs are printed, not how they are sent to bark server.
+
+To specify a handler for the bark client, you can use the `SetSlogHandler` method. This method takes a `handler` function as a parameter and sets it as the handler for the slog logger. For example, if you want to use the `JSONHandler` and print the logs as JSON objects to a file named `random.txt`, you can do this:
+
 ```go
-log := client.NewClient("<bark_server_url>", "<custom_log_level>", "<service_name>", "<session_name>", true, "<enable_bulk_dispatch_to_server>")
+package main
 
-file, _ := os.Create("<any file name>")
+import (
+	"fmt"
+	"github.com/techrail/bark/client"
+	"log/slog"
+	"os"
+)
 
-log.WithSlogHandler(slog.NewJSONHandler(file, barkslogger.Options()))
+func main() {
+	log := client.NewClient("http://127.0.0.1:8080/", "INFO", "BarkClientFileTest", "TestClientSession", true, false)
 
-log.Panic("Panic message")
-log.Alert("Alert message", true)
-log.Error("Error message")
-log.Warn("Warn message")
-log.Notice("Notice message")
-log.Info("Info message")
-log.Debug("Debug message")
-log.Println("Println message")
+	file, err := os.Create("random.txt")
+	if err != nil {
+		fmt.Println("E#1M5WRN - Error when creating new file: ", err)
+		return
+	}
+
+	// We are using JSONHandler here so the line that will be logged will actually be a JSON string
+	log.SetSlogHandler(slog.NewJSONHandler(file, client.SlogHandlerOptions()))
+	// If you want to log to STDOUT, you can use `os.Stdout` in place of the `file` as writer 
+	// Of course in case that you would have  remove the unused code from above.
+
+	log.Info("Some Message that'll be sent to random.txt file")
+	log.WaitAndEnd()
+}
 ```
-You may have noticed that we are passing some options to the `JSONHandler` using the `barkslogger.Options()` method. This is because slog has predefined labels for only four log levels: `info, warning, debug, and error`. However, bark client supports three additional log levels: `alert, panic, and notice`. The options returned by `barkslogger.Options()` define labels for these additional log levels.
+You can expect the `random.txt` file to contain something like this with different time being logged (we are using a JSON handler for slog):
+
+```text
+{"time":"2023-10-18T19:30:38.773512+05:30","level":"INFO","msg":"Some Message that'll be sent to random.txt file"}
+```
+
+You may have noticed that we are passing some options to the `JSONHandler` using the `client.SlogHandlerOptions()` method. This is because slog has predefined labels for only four log levels: `info, warning, debug, and error`. However, bark client supports three additional log levels: `alert, panic, and notice`. The options returned by `client.SlogHandlerOptions()` define labels for these additional log levels.
 
 If you add a nil options, the log labels will appear as described in the [slog documentation here](https://pkg.go.dev/log/slog#Level.String)
 
 [Slog treats log levels as integers](https://pkg.go.dev/log/slog#Level). The predefined log levels have the following values:
 
-> [!]
 > LevelDebug Level = -4 \
 > LevelInfo  Level = 0 \
 > LevelWarn  Level = 4 \
-> LevelError Level = 8 
+> LevelError Level = 8 \
 
 The custom log levels defined by bark client have the following values:
 
@@ -158,4 +162,5 @@ Notice = 3
 Alert = 9
 Panic = 10
 ```
+
 If you are writing a custom handler for slog, please make sure to handle these log levels appropriately.

--- a/models/barklog.go
+++ b/models/barklog.go
@@ -113,12 +113,12 @@ func (bld *BarkLogDao) InsertServerStartedLog() error {
 }
 
 // InsertBatch sends a batch of logs to the DB.
-func (bld *BarkLogDao) InsertBatch(l []BarkLog) error {
-	batchOfBarkLog := [][]any{}
-	for i := 0; i < len(l); i++ {
-		batchElement := []any{l[i].LogTime, l[i].LogLevel, l[i].ServiceName, l[i].SessionName,
-			l[i].Code, l[i].Message, l[i].MoreData}
-		batchOfBarkLog = append(batchOfBarkLog, batchElement)
+func (bld *BarkLogDao) InsertBatch(l *[]BarkLog) error {
+	batchOfBarkLog := make([][]any, len(*l))
+	for i := 0; i < len(*l); i++ {
+		batchElement := []any{(*l)[i].LogTime, (*l)[i].LogLevel, (*l)[i].ServiceName, (*l)[i].SessionName,
+			(*l)[i].Code, (*l)[i].Message, (*l)[i].MoreData}
+		batchOfBarkLog[i] = batchElement
 	}
 
 	_, err := resources.BarkDb.Client.CopyFrom(context.Background(), pgx.Identifier{"app_log"},

--- a/services/dbLogWriter/db_log_writer.go
+++ b/services/dbLogWriter/db_log_writer.go
@@ -17,6 +17,35 @@ func init() {
 	BarkLogDao = models.NewBarkLogDao()
 }
 
+var smallLogBatch = make([]models.BarkLog, constants.ServerLogInsertionBatchSizeSmall)
+var mediumLogBatch = make([]models.BarkLog, constants.ServerLogInsertionBatchSizeMedium)
+var largeLogBatch = make([]models.BarkLog, constants.ServerLogInsertionBatchSizeLarge)
+
+// insertBatchOfSize saves logs of the specified size to bark database.
+func insertBatchOfSize(size int, logBatch *[]models.BarkLog) {
+	for i := 0; i < size; i++ {
+		elem, ok := <-channels.LogChannel
+		if !ok {
+			fmt.Println("E#1LVMFC - Error occured while getting batch from channel")
+			break // Something went wrong
+		}
+		(*logBatch)[i] = elem
+	}
+
+	go func() {
+		defer resources.ServerDbSaverWg.Add(-size)
+		err := BarkLogDao.InsertBatch(logBatch)
+		if err != nil {
+			fmt.Println("E#1LVMIR - Batch insertion failed. Error: " + err.Error() + "\n")
+			for _, logEntry := range *logBatch {
+				fmt.Printf("E#1LVMJG - Log message: | %v\n", logEntry)
+			}
+			return
+		}
+		fmt.Printf("L#1LVM50 - Batch inserted at %s of size %d", time.Now().Format("2006-01-02 15:04:05"), size)
+	}()
+}
+
 // KeepSavingLogs is a go routine to check channel length and commit to DB
 // The routine decides whether a batch or single insert DB call of the logs is needed to be made.
 // Further bifurcation of the batch sizes is done based on the incoming traffic and LogChannel capacity.
@@ -26,79 +55,18 @@ func KeepSavingLogs() {
 	for {
 		logChannelLength = len(channels.LogChannel)
 		//fmt.Println("ChanLen: ", logChannelLength)
-		var logBatch = []models.BarkLog{}
 		if logChannelLength >= constants.ServerLogInsertionBatchSizeLarge {
 			//fmt.Println("Sending Large Batch")
 			// Bulk insert
-			for i := 0; i < constants.ServerLogInsertionBatchSizeLarge; i++ {
-				elem, ok := <-channels.LogChannel
-				if !ok {
-					fmt.Println("E#1LVMFC - Error occured while getting batch from channel")
-					break // Something went wrong
-				}
-				logBatch = append(logBatch, elem)
-			}
-
-			go func() {
-				defer resources.ServerDbSaverWg.Add(-(len(logBatch)))
-				err := BarkLogDao.InsertBatch(logBatch)
-				if err != nil {
-					fmt.Println("E#1LVMIR - Large Batch insertion failed. Error: " + err.Error() + "\n")
-					for _, logEntry := range logBatch {
-						fmt.Printf("E#1LVMJG - Log message: | %v\n", logEntry)
-					}
-					return
-				}
-				fmt.Println("L#1LVM50 - Large Batch inserted at ", time.Now().Format("2006-01-02 15:04:05"))
-			}()
+			insertBatchOfSize(constants.ServerLogInsertionBatchSizeLarge, &largeLogBatch)
 		} else if logChannelLength >= constants.ServerLogInsertionBatchSizeMedium && logChannelLength < constants.ServerLogInsertionBatchSizeLarge {
 			//fmt.Println("Sending Medium Batch")
 			// Bulk insert
-			for i := 0; i < constants.ServerLogInsertionBatchSizeMedium; i++ {
-				elem, ok := <-channels.LogChannel
-				if !ok {
-					fmt.Println("E#1LVMFF - Error occured while getting batch from channel")
-					break // Something went wrong
-				}
-				logBatch = append(logBatch, elem)
-			}
-
-			go func() {
-				defer resources.ServerDbSaverWg.Add(-(len(logBatch)))
-				err := BarkLogDao.InsertBatch(logBatch)
-				if err != nil {
-					fmt.Println("E#1LVMKR - Medium Batch insertion failed. Error: " + err.Error() + "\n")
-					for _, logEntry := range logBatch {
-						fmt.Printf("E#1LVMKU - Log message: | %v\n", logEntry)
-					}
-					return
-				}
-				fmt.Println("L#1LVMKM - Medium Batch inserted at ", time.Now().Format("2006-01-02 15:04:05"))
-			}()
+			insertBatchOfSize(constants.ServerLogInsertionBatchSizeMedium, &mediumLogBatch)
 		} else if logChannelLength >= constants.ServerLogInsertionBatchSizeSmall && logChannelLength < constants.ServerLogInsertionBatchSizeMedium {
 			//fmt.Println("Sending Small Batch")
 			// Bulk insert
-			for i := 0; i < constants.ServerLogInsertionBatchSizeSmall; i++ {
-				elem, ok := <-channels.LogChannel
-				if !ok {
-					fmt.Println("E#1LVMFL - Error occured while getting batch from channel")
-					break // Something went wrong
-				}
-				logBatch = append(logBatch, elem)
-			}
-
-			go func() {
-				defer resources.ServerDbSaverWg.Add(-(len(logBatch)))
-				err := BarkLogDao.InsertBatch(logBatch)
-				if err != nil {
-					fmt.Println("E#1LVMLE - Small Batch insertion failed. Error: " + err.Error() + "\n")
-					for _, logEntry := range logBatch {
-						fmt.Printf("E#1LVMLI - Log message: | %v\n", logEntry)
-					}
-					return
-				}
-				fmt.Println("L#1LVMFR - Small Batch inserted at ", time.Now().Format("2006-01-02 15:04:05"))
-			}()
+			insertBatchOfSize(constants.ServerLogInsertionBatchSizeMedium, &smallLogBatch)
 		} else if logChannelLength > 0 && logChannelLength < constants.ServerLogInsertionBatchSizeSmall {
 			//fmt.Println("Sending Single Log")
 			// Commit one at a time
@@ -112,6 +80,7 @@ func KeepSavingLogs() {
 				fmt.Printf("E#1LVMML - Log message: | %v\n", singleLog)
 			}
 		} else {
+			logBatch := make([]models.BarkLog, logChannelLength)
 			if appRuntime.ShutdownRequested.Load() == true {
 				if len(channels.LogChannel) == 0 {
 					return
@@ -124,7 +93,7 @@ func KeepSavingLogs() {
 						}
 						logBatch = append(logBatch, elem)
 					}
-					err := BarkLogDao.InsertBatch(logBatch)
+					err := BarkLogDao.InsertBatch(&logBatch)
 					if err != nil {
 						fmt.Println("E#1LVMN5 - Remaining Batch insertion failed. Error: " + err.Error() + "\n")
 						for _, logEntry := range logBatch {


### PR DESCRIPTION
Fixes #75
-- Added fixed size arrays and removed multiple calls to `append` to avoid multiple allocations.
-- I didn't end up removing `BarkLogDao.InsertBatch`, but made some changes to reduce allocations.